### PR TITLE
Flutter 환경 설정 가이드 및 README 업데이트

### DIFF
--- a/docs/environment-setup.md
+++ b/docs/environment-setup.md
@@ -14,7 +14,9 @@
 8. [Step 7: Android 환경 변수 설정](#step-7-android-환경-변수-설정)
 9. [Step 8: Android 라이선스 승인](#step-8-android-라이선스-승인)
 10. [Step 9: 최종 확인](#step-9-최종-확인)
-11. [트러블슈팅](#트러블슈팅)
+11. [iOS 시뮬레이터에서 앱 실행](#ios-시뮬레이터에서-앱-실행)
+12. [Android 에뮬레이터에서 앱 실행](#android-에뮬레이터에서-앱-실행)
+13. [트러블슈팅](#트러블슈팅)
 
 ---
 
@@ -288,24 +290,222 @@ grep ANDROID_HOME ~/.zshrc
 # 없다면 Step 7 다시 진행
 ```
 
----
+### 문제 6: Android 에뮬레이터에서 브라우저가 열림
 
-## 앱 실행하기
+Android 에뮬레이터에서 앱 대신 브라우저(localhost:xxxxx)가 열리는 경우:
 
-환경 설정이 완료되면 프로젝트를 실행할 수 있습니다.
+**원인**: `flutter run` 실행 시 Chrome이 기본 선택됨
 
+**해결**: 명시적으로 Android 에뮬레이터 지정
 ```bash
-# 의존성 설치
-flutter pub get
-
-# 사용 가능한 디바이스 확인
+# 디바이스 ID 확인
 flutter devices
 
-# 앱 실행
-flutter run
+# Android 에뮬레이터 명시적 지정
+flutter run -d emulator-5554
+```
 
-# 특정 디바이스에서 실행
-flutter run -d <device_id>
+### 문제 7: CocoaPods not installed (iOS)
+
+```
+✗ CocoaPods not installed.
+```
+
+**해결**:
+```bash
+# Homebrew로 설치 (권장)
+brew install cocoapods
+
+# 설치 후 iOS 의존성 설치
+cd ios && pod install && cd ..
+```
+
+### 문제 8: Android 에뮬레이터가 offline 상태
+
+```
+Device emulator-5554 is offline.
+```
+
+**해결**: 에뮬레이터 부팅 완료까지 대기 (10-30초)
+```bash
+# 잠시 대기 후 다시 확인
+sleep 10 && flutter devices
+```
+
+### 문제 9: 첫 Android 빌드가 오래 걸림
+
+첫 Android 빌드 시 NDK, CMake, Build-Tools가 자동 설치됩니다.
+
+**예상 소요 시간**: 5-10분
+
+빌드 캐시 문제 발생 시:
+```bash
+cd android
+./gradlew clean
+cd ..
+flutter run -d emulator-5554
+```
+
+### 문제 10: iOS 시뮬레이터가 목록에 없음
+
+```bash
+# Xcode 시뮬레이터 런타임 확인
+xcrun simctl list runtimes
+
+# 시뮬레이터 목록 확인
+xcrun simctl list devices
+```
+
+Xcode에서 추가 시뮬레이터 다운로드:
+1. Xcode > Settings (⌘,)
+2. Platforms 탭
+3. 원하는 iOS 버전 다운로드
+
+---
+
+## iOS 시뮬레이터에서 앱 실행
+
+### 1. iOS 의존성 설치 (최초 1회)
+
+프로젝트를 처음 실행하기 전에 iOS 의존성을 설치합니다.
+
+```bash
+# 프로젝트 루트에서
+cd ios
+pod install
+cd ..
+```
+
+> **참고**: CocoaPods가 설치되어 있지 않으면 `brew install cocoapods` 실행
+
+### 2. iOS 시뮬레이터 시작
+
+```bash
+# 사용 가능한 시뮬레이터 목록 확인
+flutter emulators
+
+# iOS 시뮬레이터 시작
+flutter emulators --launch apple_ios_simulator
+```
+
+또는 Xcode에서 직접:
+1. Xcode 실행
+2. 메뉴 **Window > Devices and Simulators** (⌘⇧2)
+3. 원하는 시뮬레이터 선택 후 부팅
+
+### 3. 앱 실행
+
+```bash
+# 연결된 디바이스 확인
+flutter devices
+
+# iOS 시뮬레이터에서 실행
+flutter run -d <simulator_id>
+
+# 예시
+flutter run -d 559086D0-91BD-4BE2-8CE6-FD5BD857A649
+```
+
+> **팁**: `flutter run`만 실행하면 여러 디바이스 중 선택할 수 있습니다.
+
+---
+
+## Android 에뮬레이터에서 앱 실행
+
+### 1. Android 에뮬레이터 생성 (최초 1회)
+
+Android Studio에서 에뮬레이터를 생성합니다.
+
+1. Android Studio 실행
+2. 메인 화면에서 **More Actions > Virtual Device Manager** 클릭
+3. **Create Device** 클릭
+4. 디바이스 선택 (예: Pixel 8, Medium Phone)
+5. 시스템 이미지 선택 (최신 API 권장)
+6. **Finish** 클릭
+
+### 2. Android 에뮬레이터 시작
+
+```bash
+# 사용 가능한 에뮬레이터 목록 확인
+flutter emulators
+
+# Android 에뮬레이터 시작 (이름은 flutter emulators 결과 참조)
+flutter emulators --launch <emulator_name>
+
+# 예시
+flutter emulators --launch Medium_Phone_API_36.1
+```
+
+또는 Android Studio에서 직접:
+1. Android Studio 실행
+2. **More Actions > Virtual Device Manager**
+3. 원하는 에뮬레이터 옆 ▶️ 버튼 클릭
+
+### 3. 앱 실행
+
+```bash
+# 연결된 디바이스 확인
+flutter devices
+
+# Android 에뮬레이터에서 실행
+flutter run -d emulator-5554
+```
+
+### 4. 첫 빌드 시 자동 설치 항목
+
+Android 앱을 처음 빌드할 때 다음 항목들이 자동으로 설치됩니다:
+- NDK (Native Development Kit)
+- Android SDK Build-Tools
+- CMake
+
+첫 빌드는 **5-10분** 정도 소요될 수 있습니다. 이후 빌드는 빠릅니다.
+
+---
+
+## 앱 실행 요약
+
+### 빠른 시작 명령어
+
+```bash
+# 1. 의존성 설치
+flutter pub get
+
+# 2. iOS 의존성 설치 (iOS 실행 시)
+cd ios && pod install && cd ..
+
+# 3. 사용 가능한 디바이스/에뮬레이터 확인
+flutter devices
+flutter emulators
+
+# 4. 시뮬레이터/에뮬레이터 시작
+flutter emulators --launch apple_ios_simulator      # iOS
+flutter emulators --launch <android_emulator_name>  # Android
+
+# 5. 앱 실행
+flutter run                    # 디바이스 선택 프롬프트
+flutter run -d <device_id>     # 특정 디바이스 지정
+```
+
+### Hot Reload 단축키
+
+앱 실행 중 터미널에서:
+
+| 키 | 동작 | 설명 |
+|----|------|------|
+| `r` | Hot Reload | 코드 변경 반영 (상태 유지) |
+| `R` | Hot Restart | 앱 재시작 (상태 초기화) |
+| `q` | 종료 | 앱 종료 |
+
+### 동시 실행
+
+iOS와 Android를 동시에 테스트하려면 터미널을 2개 열고 각각 실행:
+
+```bash
+# 터미널 1: iOS
+flutter run -d <ios_simulator_id>
+
+# 터미널 2: Android
+flutter run -d emulator-5554
 ```
 
 ---

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1,0 +1,23 @@
+PODS:
+  - Flutter (1.0.0)
+  - shared_preferences_foundation (0.0.1):
+    - Flutter
+    - FlutterMacOS
+
+DEPENDENCIES:
+  - Flutter (from `Flutter`)
+  - shared_preferences_foundation (from `.symlinks/plugins/shared_preferences_foundation/darwin`)
+
+EXTERNAL SOURCES:
+  Flutter:
+    :path: Flutter
+  shared_preferences_foundation:
+    :path: ".symlinks/plugins/shared_preferences_foundation/darwin"
+
+SPEC CHECKSUMS:
+  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  shared_preferences_foundation: 7036424c3d8ec98dfe75ff1667cb0cd531ec82bb
+
+PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
+
+COCOAPODS: 1.16.2

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -10,7 +10,9 @@
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
 		331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 331C807B294A618700263BE5 /* RunnerTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
+		3E4481FA156A04348D477702 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CA3640F9EFC0E8DB896636AD /* Pods_Runner.framework */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		8B6C15FD16FE3FDE35A21B09 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 312F4E0C14BDC7AB65A87461 /* Pods_RunnerTests.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
@@ -42,12 +44,18 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		2D0A251F9E2ECF74A31B148F /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		312F4E0C14BDC7AB65A87461 /* Pods_RunnerTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_RunnerTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		331C807B294A618700263BE5 /* RunnerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunnerTests.swift; sourceTree = "<group>"; };
 		331C8081294A63A400263BE5 /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		423A53EF9D2CE4EE151272BE /* Pods-RunnerTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.release.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.release.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		74F3815262E9EFEAC942077A /* Pods-RunnerTests.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.profile.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.profile.xcconfig"; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		7E1B64004361764FE4D8A5FC /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		80E2D7E53F3EF689CD029D32 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -55,13 +63,24 @@
 		97C146FD1CF9000F007C117D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		97C147001CF9000F007C117D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		985C2DC26C63EA30E1822CA1 /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
+		CA3640F9EFC0E8DB896636AD /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		8C70925F26437EBC8052D253 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8B6C15FD16FE3FDE35A21B09 /* Pods_RunnerTests.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3E4481FA156A04348D477702 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -74,6 +93,29 @@
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
 			);
 			path = RunnerTests;
+			sourceTree = "<group>";
+		};
+		3E756BEE77FA6A605A67CE62 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				2D0A251F9E2ECF74A31B148F /* Pods-Runner.debug.xcconfig */,
+				7E1B64004361764FE4D8A5FC /* Pods-Runner.release.xcconfig */,
+				80E2D7E53F3EF689CD029D32 /* Pods-Runner.profile.xcconfig */,
+				985C2DC26C63EA30E1822CA1 /* Pods-RunnerTests.debug.xcconfig */,
+				423A53EF9D2CE4EE151272BE /* Pods-RunnerTests.release.xcconfig */,
+				74F3815262E9EFEAC942077A /* Pods-RunnerTests.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		894C0CCBBF653EB26057B745 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				CA3640F9EFC0E8DB896636AD /* Pods_Runner.framework */,
+				312F4E0C14BDC7AB65A87461 /* Pods_RunnerTests.framework */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
@@ -94,6 +136,8 @@
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
 				331C8082294A63A400263BE5 /* RunnerTests */,
+				3E756BEE77FA6A605A67CE62 /* Pods */,
+				894C0CCBBF653EB26057B745 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -128,8 +172,10 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 331C8087294A63A400263BE5 /* Build configuration list for PBXNativeTarget "RunnerTests" */;
 			buildPhases = (
+				69331DAE7AEF2F71D2A817D4 /* [CP] Check Pods Manifest.lock */,
 				331C807D294A63A400263BE5 /* Sources */,
 				331C807F294A63A400263BE5 /* Resources */,
+				8C70925F26437EBC8052D253 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -145,12 +191,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				6F243E71FE9C52FE69616533 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				DC06B1BAB4298B5951D207BF /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -238,6 +286,50 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		69331DAE7AEF2F71D2A817D4 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-RunnerTests-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6F243E71FE9C52FE69616533 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			alwaysOutOfDate = 1;
@@ -252,6 +344,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		DC06B1BAB4298B5951D207BF /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -378,6 +487,7 @@
 		};
 		331C8088294A63A400263BE5 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 985C2DC26C63EA30E1822CA1 /* Pods-RunnerTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -395,6 +505,7 @@
 		};
 		331C8089294A63A400263BE5 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 423A53EF9D2CE4EE151272BE /* Pods-RunnerTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
@@ -410,6 +521,7 @@
 		};
 		331C808A294A63A400263BE5 /* Profile */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 74F3815262E9EFEAC942077A /* Pods-RunnerTests.profile.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;

--- a/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>


### PR DESCRIPTION
## Summary
- iOS 시뮬레이터 및 Android 에뮬레이터 실행 가이드 추가
- 트러블슈팅 섹션 확장 (문제 6-10 추가)
- Hot Reload 단축키 및 동시 실행 가이드 추가

## Changes

```
docs/
└── environment-setup.md           # iOS/Android 실행 가이드 추가
ios/
├── Podfile.lock                   # CocoaPods 의존성 잠금 파일
├── Runner.xcodeproj/
│   └── project.pbxproj            # Xcode 프로젝트 설정
└── Runner.xcworkspace/
    └── contents.xcworkspacedata   # Workspace 설정
```

## Commits
- [`5c140f7`](https://github.com/Orchemi/flutter-practice/commit/5c140f7b544919482cf08e69a2e0d71e2852607f) docs: iOS Android 시뮬레이터 실행 가이드 추가

## Test plan
- [ ] iOS 시뮬레이터에서 앱 실행 확인
- [ ] Android 에뮬레이터에서 앱 실행 확인
- [ ] 문서 가이드 따라 환경 설정 가능 여부 확인

<img width="909" height="901" alt="image" src="https://github.com/user-attachments/assets/8a4bf32c-4232-44a2-9b9a-b8888e466cf7" />